### PR TITLE
add cscw 2025 deadline

### DIFF
--- a/conferences/cscw.yml
+++ b/conferences/cscw.yml
@@ -34,3 +34,13 @@
   start: 2024-11-09
   end: 2024-11-13
   sub: CSCW
+
+- title: CSCW (October cycle)
+  year: 2025
+  id: cscw25_october
+  link: https://cscw.acm.org/2025/index.php/submit-papers/
+  deadline: '2024-10-29 23:59:59'
+  timezone: UTC-12
+  place: TBD
+  date: October/November 2025
+  sub: CSCW


### PR DESCRIPTION
Hello team!

I'd like to include the CSCW deadline. The webpage indicates deadlines for the journal submissions, but the conference location and dates haven't been officially announced yet - so I haven't included the start/end dates.

Mark 