### PR TITLE
Fix indentation

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: yaml-lint
+        uses: ibiqlik/action-yamllint@v3.1.1
   build:
     runs-on: ubuntu-latest
     steps:

--- a/conferences/haips.yml
+++ b/conferences/haips.yml
@@ -1,12 +1,12 @@
 - title: HAIPS
-   year: 2025
-   id: haips25
-   full_name: 1st Workshop on Human-Centered AI Privacy and Security
-   link: https://haips.com
-   deadline: 2025-06-20 23:59
-   timezone: UTC-12
-   place: Taipei, Taiwan
-   date: October, 17, 2025
-   paperslink: https://haips.com
-   sub: ['AI', 'SP', 'HCI']
-   note: co-located with ACM CCS 2025
+  year: 2025
+  id: haips25
+  full_name: 1st Workshop on Human-Centered AI Privacy and Security
+  link: https://haips.com
+  deadline: 2025-06-20 23:59
+  timezone: UTC-12
+  place: Taipei, Taiwan
+  date: October, 17, 2025
+  paperslink: https://haips.com
+  sub: ['AI', 'SP', 'HCI']
+  note: co-located with ACM CCS 2025


### PR DESCRIPTION
Invalid YAML (3 instead of 2 spaces) made CI pipeline fail (`mapping values are not allowed in this context`).

Commit https://github.com/hci-deadlines/conf-database/pull/16/commits/35f3c55fcbff60aa57dc105002c73f137936106e fixes the concrete issue, commit https://github.com/hci-deadlines/conf-database/pull/16/commits/243fc3193a6bdd4c254476634acdab7cf70e4961 might help avoid it in the future: its syntax check might result in clearer error messages for invalid YAML