### PR TITLE
Add IEEEVR 2026

### DIFF
--- a/conferences/vr.yml
+++ b/conferences/vr.yml
@@ -40,3 +40,17 @@
   start: 2025-03-08
   end: 2025-03-12
   sub: XR
+
+- title: IEEE VR
+  year: 2026
+  id: ieeevr2026
+  full_name: IEEE Conference on Virtual Reality and 3D User Interfaces
+  link: https://ieeevr.org/2026/contribute/papers/
+  deadline: '2025-09-12 23:59:59'
+  abstract_deadline: '2025-09-05 23:59:59'
+  timezone: UTC-12
+  place: Daegu, Korea
+  date: March, 21-25, 2026
+  start: 2026-03-21
+  end: 2026-03-25
+  sub: XR


### PR DESCRIPTION
Dates have recently been published at https://ieeevr.org/2026/contribute/papers/