### PR TITLE
Fix yml data errors across 5 conference files

### DIFF
--- a/conferences/autoui.yml
+++ b/conferences/autoui.yml
@@ -42,7 +42,7 @@
   id: autoui26
   link: https://www.auto-ui.org/26/papers/
   deadline: "2026-04-09 23:59:59"
-  abstract_deadline: "2025-04-02 23:59:59"
+  abstract_deadline: "2026-04-02 23:59:59"
   timezone: UTC-12
   place: Gothenburg, Sweden
   date: September, 20-23, 2026

--- a/conferences/imwut.yml
+++ b/conferences/imwut.yml
@@ -117,8 +117,8 @@
   timezone: UTC-12
   place: Shanghai, China
   date: October, 13-15, 2026
-  start: 2025-10-13
-  end: 2025-10-15
+  start: 2026-10-13
+  end: 2026-10-15
   sub: HCI
 
 - title: IMWUT (Ubicomp/ISWC)
@@ -129,8 +129,8 @@
   timezone: UTC-12
   place: Shanghai, China
   date: October, 13-15, 2026
-  start: 2025-10-13
-  end: 2025-10-15
+  start: 2026-10-13
+  end: 2026-10-15
   sub: HCI
 
 - title: IMWUT (Ubicomp/ISWC)
@@ -141,8 +141,8 @@
   timezone: UTC-12
   place: Shanghai, China
   date: October, 13-15, 2026
-  start: 2025-10-13
-  end: 2025-10-15
+  start: 2026-10-13
+  end: 2026-10-15
   sub: HCI
 
 - title: IMWUT (Ubicomp/ISWC)

--- a/conferences/iss.yml
+++ b/conferences/iss.yml
@@ -41,6 +41,7 @@
   deadline: '2025-03-14 23:59:59'
   timezone: UTC-12
   place: N/A (conference postponed to 2026)
+  sub: HCI
 
 - title: ISS (Second round)
   year: 2025

--- a/conferences/mobilehci.yml
+++ b/conferences/mobilehci.yml
@@ -44,7 +44,7 @@
   abstract_deadline: '2026-01-22 23:59:59'
   timezone: UTC-12
   place: Swansea, Wales, United Kingdom
-  date: August 31 - September 03, 2025
+  date: August 31 - September 03, 2026
   start: 2026-08-31
   end: 2026-09-03
   sub: HCI

--- a/conferences/nordichi.yml
+++ b/conferences/nordichi.yml
@@ -1,13 +1,13 @@
 - title: NordiCHI
   year: 2026
-  id: nordichi22
+  id: nordichi26
   full_name: Nordic Conference on Human-Computer Interaction
   link: https://sites.uwasa.fi/nordichi2026/
   deadline: 2026-04-23 23:59
   abstract_deadline: 2026-04-16 23:59
   timezone: UTC-12
   place: Vaasa, Finland
-  date: October, 3-4, 2026
-  start: 2026-10-3
-  end: 2026-10-4
+  date: October, 3-7, 2026
+  start: 2026-10-03
+  end: 2026-10-07
   sub: HCI


### PR DESCRIPTION
## Summary

Five small data corrections, one commit per file. Every change verified against the conference's own CFP page (links below).

| File | Fix | Source |
|---|---|---|
| nordichi.yml | `id: nordichi22` -> `nordichi26` and dates extended to cover workshops + main conference (Oct 3-7) | https://sites.uwasa.fi/nordichi2026/ |
| autoui.yml | AutoUI 2026 `abstract_deadline` year 2025 -> 2026 | https://www.auto-ui.org/26/papers/ |
| imwut.yml | IMWUT 2026 rounds 1-3 `start`/`end` years 2025 -> 2026 (round 4 was already correct) | https://www.ubicomp.org/ubicomp-iswc-2026/ |
| mobilehci.yml | MobileHCI 2026 prose `date` year 2025 -> 2026 (start/end were already correct) | https://mobilehci.acm.org/2026/ |
| iss.yml | Add missing `sub: HCI` to `iss25a` so it matches the README schema and the sibling `iss25b` row | https://iss.acm.org/2025/ |
