### PR TITLE
Add HRI 2027, DIS 2027, and VIS 2026

### DIFF
--- a/conferences/dis.yml
+++ b/conferences/dis.yml
@@ -49,3 +49,17 @@
   start: 2026-06-13
   end: 2026-06-17
   sub: DES
+
+- title: DIS
+  year: 2027
+  id: dis27
+  link: https://dis.acm.org/2027/
+  deadline: '2027-01-18 23:59:59'
+  abstract_deadline: '2027-01-11 23:59:59'
+  timezone: UTC-12
+  place: Stockholm, Sweden
+  date: June, 28 - July, 2, 2027
+  start: 2027-06-28
+  end: 2027-07-02
+  sub: DES
+  note: Provisional submission dates

--- a/conferences/hri.yml
+++ b/conferences/hri.yml
@@ -47,3 +47,16 @@
   start: 2026-03-16
   end: 2026-03-19
   sub: HRI
+
+- title: HRI
+  year: 2027
+  id: hri27
+  link: https://humanrobotinteraction.org/2027/
+  deadline: '2026-09-18 23:59:59'
+  abstract_deadline: '2026-09-11 23:59:59'
+  timezone: UTC-12
+  place: Santa Clara, California, USA
+  date: March, 8-12, 2027
+  start: 2027-03-08
+  end: 2027-03-12
+  sub: HRI

--- a/conferences/vis.yml
+++ b/conferences/vis.yml
@@ -49,3 +49,16 @@
   start: 2025-11-02
   end: 2025-11-07
   sub: VIS
+
+- title: VIS
+  year: 2026
+  id: vis26
+  link: https://ieeevis.org/year/2026/welcome/
+  deadline: '2026-03-31 23:59:59'
+  abstract_deadline: '2026-03-21 23:59:59'
+  timezone: UTC-12
+  place: Boston, Massachusetts, USA
+  date: November, 9-13, 2026
+  start: 2026-11-09
+  end: 2026-11-13
+  sub: VIS


### PR DESCRIPTION
## Summary of This PR

Adds HRI 2027, DIS 2027, and IEEE VIS 2026 to their existing files, one commit per file. Conference dates, locations, and paper deadlines were checked against the official conference pages. DIS submission dates are marked provisional.

Sources: [HRI 2027](https://humanrobotinteraction.org/2027/submissions/), [DIS 2027](https://dis.acm.org/2027/contributing/), [IEEE VIS deadlines](https://ieeevis.org/year/2026/info/call-participation/paper-submission-guidelines/), [IEEE VIS location](https://ieeevis.org/year/2026/welcome/)