### PR TITLE
Add 2027 IMWUT submission deadlines

### DIFF
--- a/conferences/imwut.yml
+++ b/conferences/imwut.yml
@@ -156,3 +156,51 @@
   start: 2026-10-13
   end: 2026-10-15
   sub: HCI
+
+- title: IMWUT (Ubicomp/ISWC)
+  year: 2027
+  id: imwut27_1
+  link: https://dl.acm.org/journal/imwut/how-to-submit
+  deadline: '2026-11-01 23:59:59'
+  timezone: UTC-12
+  place: Seoul Dragon City, Seoul, Republic of Korea
+  date: October, 03-07, 2027
+  start: 2027-10-03
+  end: 2027-10-07
+  sub: HCI
+
+- title: IMWUT (Ubicomp/ISWC)
+  year: 2027
+  id: imwut27_2
+  link: https://dl.acm.org/journal/imwut/how-to-submit
+  deadline: '2027-02-01 23:59:59'
+  timezone: UTC-12
+  place: Seoul Dragon City, Seoul, Republic of Korea
+  date: October, 03-07, 2027
+  start: 2027-10-03
+  end: 2027-10-07
+  sub: HCI
+
+- title: IMWUT (Ubicomp/ISWC)
+  year: 2027
+  id: imwut27_3
+  link: https://dl.acm.org/journal/imwut/how-to-submit
+  deadline: '2027-05-01 23:59:59'
+  timezone: UTC-12
+  place: Seoul Dragon City, Seoul, Republic of Korea
+  date: October, 03-07, 2027
+  start: 2027-10-03
+  end: 2027-10-07
+  sub: HCI
+
+- title: IMWUT - resubmission only (Ubicomp/ISWC)
+  year: 2027
+  id: imwut27_4
+  link: https://dl.acm.org/journal/imwut/how-to-submit
+  deadline: '2027-08-01 23:59:59'
+  timezone: UTC-12
+  place: Seoul Dragon City, Seoul, Republic of Korea
+  date: October, 03-07, 2027
+  start: 2027-10-03
+  end: 2027-10-07
+  sub: HCI


### PR DESCRIPTION
* (conferences/imwut.yml): Add four 2027 IMWUT deadlines, including one resubmission deadline and the event details in Seoul.

The website for 2027 itself is not up yet, using
https://dl.acm.org/journal/imwut/how-to-submit and https://sigchi.org/events/ubicomp-2027/ as references for this.